### PR TITLE
Fixed issue of crashing on changed focus to workspace by number instead

### DIFF
--- a/src/workspace.c
+++ b/src/workspace.c
@@ -500,7 +500,7 @@ static void _workspace_show(Con *workspace) {
     ewmh_update_current_desktop();
 
     /* Push any sticky windows to the now visible workspace. */
-    output_push_sticky_windows(old_focus);
+    output_push_sticky_windows(focused);
 }
 
 /*


### PR DESCRIPTION
i3 gaps (master i3 too) has a bug, where if I refer to the workspaces by number (names change dynamically in my use-case), then sometimes on switching to a yet unopened workspace leads to crash and logout.
I traced this issue to the src/workspace.c source, where the function `_workspace_show(Con *workspace)` accesses the previous workspace, after it was destroyed in this function, leading to access violation. Changing `output_push_sticky_windows(old_focus)` to `output_push_sticky_windows(focused)` fixes the issue. Other use-cases than mine may theoretically be affected.