### PR TITLE
Add `solo_no_gaps` option for `smart_borders`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ This will disable all gaps (outer and inner) on the workspace whenever only one 
 
 ### Smart Borders
 
-Based on the patch from [i3-extras](https://github.com/ashinkarov/i3-extras), smart borders have been added in a configurable way. If activated, this patch will draw borders around a container only if it is not the only container in this workspace. It is disabled by default and can be activated with the command below. `on` will always activate it, while `no_gaps` will only activate it if the gap size to the edge of the screen is `0`.
+Based on the patch from [i3-extras](https://github.com/ashinkarov/i3-extras), smart borders have been added in a configurable way. If activated, this patch will draw borders around a container only if it is not the only container in this workspace. It is disabled by default and can be activated with the command below. `on` will always activate it, while `no_gaps` will only activate it if the gap size to the edge of the screen is `0`. `solo_no_gaps` combines these rules and only hides borders in workspaces with no gaps *and* only one container.
 
 ```
-smart_borders on|no_gaps
+smart_borders on|no_gaps|solo_no_gaps
 ```
 
 

--- a/include/data.h
+++ b/include/data.h
@@ -79,7 +79,8 @@ typedef enum { ADJ_NONE = 0,
 
 typedef enum { OFF,
                ON,
-               NO_GAPS } smart_borders_t;
+               NO_GAPS,
+               SOLO_NO_GAPS } smart_borders_t;
 
 typedef enum { HEBM_NONE = ADJ_NONE,
                HEBM_VERTICAL = ADJ_LEFT_SCREEN_EDGE | ADJ_RIGHT_SCREEN_EDGE,

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -74,10 +74,13 @@ state GAPS_WITH_SCOPE:
 
 # smart_borders true|false
 # smart_borders no_gaps
+# smart_borders solo_no_gaps
 state SMART_BORDERS:
   enabled = '1', 'yes', 'true', 'on', 'enable', 'active'
       -> call cfg_smart_borders($enabled)
   enabled = 'no_gaps'
+      -> call cfg_smart_borders($enabled)
+  enabled = 'solo_no_gaps'
       -> call cfg_smart_borders($enabled)
 
 # smart_gaps on|off

--- a/src/con.c
+++ b/src/con.c
@@ -1586,6 +1586,7 @@ Con *con_descend_direction(Con *con, direction_t direction) {
 Rect con_border_style_rect(Con *con) {
     if ((config.smart_borders == ON && con_num_visible_children(con_get_workspace(con)) <= 1) ||
         (config.smart_borders == NO_GAPS && calculate_effective_gaps(con).outer == 0) ||
+        (config.smart_borders == SOLO_NO_GAPS && calculate_effective_gaps(con).outer == 0 && con_num_visible_children(con_get_workspace(con)) <= 1) ||
         (config.hide_edge_borders == HEBM_SMART && con_num_visible_children(con_get_workspace(con)) <= 1)) {
         if (!con_is_floating(con))
             return (Rect){0, 0, 0, 0};

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -210,6 +210,8 @@ CFGFUN(gaps, const char *workspace, const char *scope, const long value) {
 CFGFUN(smart_borders, const char *enable) {
     if (!strcmp(enable, "no_gaps"))
         config.smart_borders = NO_GAPS;
+    else if (!strcmp(enable, "solo_no_gaps"))
+        config.smart_borders = SOLO_NO_GAPS;
     else
         config.smart_borders = eval_boolstr(enable) ? ON : OFF;
 }


### PR DESCRIPTION
Adds `solo_no_gaps` option for `smart_borders`

This combined the behaviour of the other two modes to only hide borders if the workspace has a single container *and* effective edge gaps are 0

Addresses #177 