### PR TITLE
Searching for libiconv - OpenBSD support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,8 @@ AC_SEARCH_LIBS([ev_run], [ev], , [AC_MSG_FAILURE([cannot find the required ev_ru
 
 AC_SEARCH_LIBS([shm_open], [rt])
 
-AC_SEARCH_LIBS([iconv_open], [iconv], , [AC_MSG_FAILURE([cannot find the required iconv_open() function despite trying to link with -liconv])])
+AC_SEARCH_LIBS([iconv_open], [iconv], ,
+AC_SEARCH_LIBS([libiconv_open], [iconv], , [AC_MSG_FAILURE([cannot find the required iconv_open() function despite trying to link with -liconv])]))
 
 AX_PTHREAD
 


### PR DESCRIPTION
I have only been able to test this build change on OpenBSD, so I'm not sure if it causes any other effects on different platforms. However I can confirm this change is needed for the project to build on OpenBSD.

I would also like to provide some install commands here to go along with this change. You may feel free to copy and paste them to the wiki if you'd also like them there:

$ = $USER and # = root

Note: we install regular `i3` here first to get it and it's dependencies. Don't worry, i3-gaps will take it's place.

First off:

```bash
# pkg_add i3 git gmake automake libiconv
# pkg_add autoconf
# pkg_add automake
```

I've listed these as separate commands so when installing `autoconf` and `automake`, you are able to select which version you'd like. Please take note of which version you install. At the time of writing this, the version of `autoconf` I'm using is `2.69` and the version of `automake` is `1.15`.

```bash
$ export AUTOCONF_VERSION=2.69
$ export AUTOMAKE_VERSION=1.15
$ git clone https://github.com/Airblader/i3
$ cd i3
```

This clone requires the changes I have made in this PR. If it does not get / is not merged, checkout my branch or make the small change yourself.

```bash
$ autoreconf --force --install
$ mkdir build
$ cd build
$ LDFLAGS="-L/usr/local/lib" ../configure --prefix=/usr/local --sysconfdir=/etc --disable-sanitizers
$ gmake
# gmake install
```

Add `exec i3` to your `~/.xinitrc` file and then run `startx`.

You now have i3-gaps running on OpenBSD 😄 