### PR TITLE
For resizing, convert pixel diff to percentage, based on parent.

### DIFF
--- a/include/resize.h
+++ b/include/resize.h
@@ -33,7 +33,7 @@ bool resize_neighboring_cons(Con *first, Con *second, int px, int ppt);
 double percent_for_1px(Con *con);
 
 /**
- * Calculate the given container's new percent given a change in pixels.
+ * Calculate and return the given container's percentage change given a change in pixels.
  *
  */
 double px_resize_to_percent(Con *con, int px_diff);

--- a/src/commands.c
+++ b/src/commands.c
@@ -537,8 +537,8 @@ static bool cmd_resize_tiling_width_height(I3_CMD, Con *current, const char *dir
     if (ppt != 0.0) {
         new_current_percent = current->percent + ppt;
     } else {
-        new_current_percent = px_resize_to_percent(current, px);
-        ppt = new_current_percent - current->percent;
+        ppt = px_resize_to_percent(current, px);
+        new_current_percent = current->percent + ppt;
     }
     subtract_percent = ppt / (children - 1);
     if (ppt < 0.0 && new_current_percent < percent_for_1px(current)) {

--- a/src/resize.c
+++ b/src/resize.c
@@ -102,16 +102,15 @@ bool resize_find_tiling_participants(Con **current, Con **other, direction_t dir
 }
 
 /*
- * Calculate the given container's new percent given a change in pixels.
+ * Calculate and return the given container's percentage change given a change in pixels.
  *
  */
 double px_resize_to_percent(Con *con, int px_diff) {
     Con *parent = con->parent;
     const orientation_t o = con_orientation(parent);
     const int total = (o == HORIZ ? parent->rect.width : parent->rect.height);
-    /* deco_rect.height is subtracted from each child in render_con_split */
-    const int target = px_diff + (o == HORIZ ? con->rect.width : con->rect.height + con->deco_rect.height);
-    return ((double)target / (double)total);
+
+    return (double)px_diff / (double)total;
 }
 
 /*
@@ -145,8 +144,9 @@ bool resize_neighboring_cons(Con *first, Con *second, int px, int ppt) {
         new_first_percent = first->percent + ((double)ppt / 100.0);
         new_second_percent = second->percent - ((double)ppt / 100.0);
     } else {
-        new_first_percent = px_resize_to_percent(first, px);
-        new_second_percent = second->percent + first->percent - new_first_percent;
+        const double percent_change = px_resize_to_percent(first, px);
+        new_first_percent = first->percent + percent_change;
+        new_second_percent = second->percent - percent_change;
     }
     /* Ensure that no container will be less than 1 pixel in the resizing
      * direction. */
@@ -233,6 +233,11 @@ void resize_graphical_handler(Con *first, Con *second, orientation_t orientation
 
     int pixels = (new_position - initial_position);
     DLOG("Done, pixels = %d\n", pixels);
+
+    /* No change; no action needed. */
+    if (pixels == 0) {
+        return;
+    }
 
     /* if we got thus far, the containers must have valid percentages. */
     assert(first->percent > 0.0);


### PR DESCRIPTION
Fixes #247

Also, premature return on no change.

The way it worked previously was buggy with gaps. It affected either only leaf containers, or non-leaf containers, not sure which.

It first calculated the one of the containers' next percentage, and then subtracted the previous percentage to find the actual change. Now it directly calculates the change, and subtracts and adds the change to the two affected containers.

The function is used in two places. When [resizing via mouse drag](https://github.com/Airblader/i3/pull/252/files#diff-9f7e40a7c83fbbc8dec32e46bea26567R147), and then in [cmd_resize_tiling_width_height](https://github.com/Airblader/i3/pull/252/files#diff-75bd1443560c3507928c1f5d5d351e21R540). I couldn't figure out how to trigger the second event, so I am not completely sure it is a non-breaking change.