### PR TITLE
Fix tiling issue described in #22

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -2275,12 +2275,6 @@ gaps_t calculate_effective_gaps(Con *con) {
         gaps.left = workspace->gaps.left + config.gaps.left;
     }
 
-    /* Outer gaps are added on top of inner gaps. */
-    gaps.top += 2 * gaps.inner;
-    gaps.right += 2 * gaps.inner;
-    gaps.bottom += 2 * gaps.inner;
-    gaps.left += 2 * gaps.inner;
-
     return gaps;
 }
 

--- a/src/render.c
+++ b/src/render.c
@@ -49,16 +49,27 @@ void render_con(Con *con, bool already_inset) {
     DLOG("Rendering node %p / %s / layout %d / children %d\n", con, con->name,
          con->layout, params.children);
 
+    if (con->type == CT_WORKSPACE) {
+        gaps_t gaps = calculate_effective_gaps(con);
+        Rect inset = {
+            gaps.left,
+            gaps.top,
+            -(gaps.left + gaps.right),
+            -(gaps.top + gaps.bottom)};
+        con->rect = rect_add(con->rect, inset);
+        params.rect = rect_add(params.rect, inset);
+        params.x += gaps.left;
+        params.y += gaps.top;
+    }
+
     bool should_inset = should_inset_con(con, params.children);
     if (!already_inset && should_inset) {
         gaps_t gaps = calculate_effective_gaps(con);
         Rect inset = (Rect){
-            has_adjacent_container(con, D_LEFT) ? gaps.inner : gaps.left,
-            has_adjacent_container(con, D_UP) ? gaps.inner : gaps.top,
-            has_adjacent_container(con, D_RIGHT) ? -gaps.inner : -gaps.right,
-            has_adjacent_container(con, D_DOWN) ? -gaps.inner : -gaps.bottom};
-        inset.width -= inset.x;
-        inset.height -= inset.y;
+            gaps.inner,
+            gaps.inner,
+            -2 * gaps.inner,
+            -2 * gaps.inner};
 
         if (con->fullscreen_mode == CF_NONE) {
             params.rect = rect_add(params.rect, inset);


### PR DESCRIPTION
Currently, containers only consider their neighbors and screen edges
If >2 containers are in a line, the outer containers adjust from outer gaps, but the middle containers know nothing of this and only consider the inner gaps
When the outer gaps differ substantially from the inner gaps, the outer containers are smaller as only they adjust for the larger outer gaps

With this change, containers always inset by the inner gap settings, and the workspace is now inset by the outer gap settings
The result is that many tiled containers have the same size, and the gaps overall work as the user might expect them to
Previous combinations of outer/inner gap settings still produce the same result, albeit with fixed outer-most sizes