### PR TITLE
Add `gaps <type> <scope> toggle <px>` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ gaps left <px>
 Additionally, you can issue commands with the following syntax. This is useful, for example, to bind keys to changing the gap size:
 
 ```
-gaps inner|outer|horizontal|vertical|top|right|bottom|left current|all set|plus|minus <px>
+gaps inner|outer|horizontal|vertical|top|right|bottom|left current|all set|plus|minus|toggle <px>
 
 # Examples
 gaps inner all set 20
 gaps outer current plus 5
 gaps horizontal current plus 40
+gaps outer current toggle 60
 ```
 
 Here are the individual parts explained:

--- a/include/commands.h
+++ b/include/commands.h
@@ -327,7 +327,7 @@ void cmd_shmlog(I3_CMD, const char *argument);
 void cmd_debuglog(I3_CMD, const char *argument);
 
 /**
- * Implementation of 'gaps inner|outer|top|right|bottom|left|horizontal|vertical current|all set|plus|minus <px>'
+ * Implementation of 'gaps inner|outer|top|right|bottom|left|horizontal|vertical current|all set|plus|minus|toggle <px>'
  *
  */
 void cmd_gaps(I3_CMD, const char *type, const char *scope, const char *mode, const char *value);

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -94,7 +94,7 @@ state BORDER:
   '1pixel'
     -> call cmd_border("pixel", 1)
 
-# gaps inner|outer|horizontal|vertical|top|right|bottom|left [current] [set|plus|minus] <px>
+# gaps inner|outer|horizontal|vertical|top|right|bottom|left [current] [set|plus|minus|toggle] <px>
 state GAPS:
   type = 'inner', 'outer', 'horizontal', 'vertical', 'top', 'right', 'bottom', 'left'
       -> GAPS_WITH_TYPE
@@ -104,7 +104,7 @@ state GAPS_WITH_TYPE:
       -> GAPS_WITH_SCOPE
 
 state GAPS_WITH_SCOPE:
-  mode = 'plus', 'minus', 'set'
+  mode = 'plus', 'minus', 'set', 'toggle'
       -> GAPS_WITH_MODE
 
 state GAPS_WITH_MODE:

--- a/src/commands.c
+++ b/src/commands.c
@@ -2199,7 +2199,7 @@ void cmd_debuglog(I3_CMD, const char *argument) {
 }
 
 /**
- * Implementation of 'gaps inner|outer|top|right|bottom|left|horizontal|vertical current|all set|plus|minus <px>'
+ * Implementation of 'gaps inner|outer|top|right|bottom|left|horizontal|vertical current|all set|plus|minus|toggle <px>'
  *
  */
 void cmd_gaps(I3_CMD, const char *type, const char *scope, const char *mode, const char *value) {
@@ -2219,6 +2219,9 @@ void cmd_gaps(I3_CMD, const char *type, const char *scope, const char *mode, con
             current_value -= pixels;                                   \
         else if (!strcmp(mode, "set")) {                               \
             current_value = pixels;                                    \
+            reset = true;                                              \
+        } else if (!strcmp(mode, "toggle")) {                          \
+            current_value = !current_value * pixels;                   \
             reset = true;                                              \
         } else {                                                       \
             ELOG("Invalid mode %s when changing gaps", mode);          \


### PR DESCRIPTION
Makes it possible to do something like `bindsym $mod+g gaps horizontal current toggle 640` to add 640px gaps if there are none, or remove gaps if they're present.