### PR TITLE
Add inverse_outer mode to smart gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ smart_gaps on
 
 This will disable all gaps (outer, inner, horizontal, vertical, top, right, bottom, left) on the workspace whenever only one container is on the current workspace.
 
+There is another mode which does the opposite:
+
+```
+smart_gaps inverse_outer
+```
+
+This one will only show outer gaps if there is only one visible container.  
+This is useful if you have a large monitor and want to keep single windows centered on screen.  
+Inner gaps are always shown. You can compensate for that by picking sensible values for your outer gaps, negative sizes are accepted.
 
 ### Smart Borders
 

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -262,7 +262,7 @@ struct Config {
     smart_borders_t smart_borders;
 
     /* Disable gaps if there is only one container on the workspace */
-    bool smart_gaps;
+    smart_gaps_t smart_gaps;
 };
 
 /**

--- a/include/data.h
+++ b/include/data.h
@@ -77,9 +77,13 @@ typedef enum { ADJ_NONE = 0,
                ADJ_UPPER_SCREEN_EDGE = (1 << 2),
                ADJ_LOWER_SCREEN_EDGE = (1 << 4) } adjacent_t;
 
-typedef enum { OFF,
-               ON,
-               NO_GAPS } smart_borders_t;
+typedef enum { SMART_BORDERS_OFF,
+               SMART_BORDERS_ON,
+               SMART_BORDERS_NO_GAPS } smart_borders_t;
+
+typedef enum { SMART_GAPS_OFF,
+               SMART_GAPS_ON,
+               SMART_GAPS_INVERSE_OUTER } smart_gaps_t;
 
 typedef enum { HEBM_NONE = ADJ_NONE,
                HEBM_VERTICAL = ADJ_LEFT_SCREEN_EDGE | ADJ_RIGHT_SCREEN_EDGE,

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -87,6 +87,8 @@ state SMART_BORDERS:
 state SMART_GAPS:
   enabled = '1', 'yes', 'true', 'on', 'enable', 'active'
       -> call cfg_smart_gaps($enabled)
+  enabled = 'inverse_outer'
+      -> call cfg_smart_gaps($enabled)
 
 # floating_minimum_size <width> x <height>
 state FLOATING_MINIMUM_SIZE_WIDTH:

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -306,13 +306,16 @@ CFGFUN(gaps, const char *workspace, const char *scope, const long value) {
 
 CFGFUN(smart_borders, const char *enable) {
     if (!strcmp(enable, "no_gaps"))
-        config.smart_borders = NO_GAPS;
+        config.smart_borders = SMART_BORDERS_NO_GAPS;
     else
-        config.smart_borders = eval_boolstr(enable) ? ON : OFF;
+        config.smart_borders = eval_boolstr(enable) ? SMART_BORDERS_ON : SMART_BORDERS_OFF;
 }
 
 CFGFUN(smart_gaps, const char *enable) {
-    config.smart_gaps = eval_boolstr(enable);
+    if (!strcmp(enable, "inverse_outer"))
+        config.smart_gaps = SMART_GAPS_INVERSE_OUTER;
+    else
+        config.smart_gaps = eval_boolstr(enable) ? SMART_GAPS_ON : SMART_GAPS_OFF;
 }
 
 CFGFUN(floating_minimum_size, const long width, const long height) {


### PR DESCRIPTION
Here's an implementation for #263.
This adds a new value to the `smart_gaps` config directive which makes outer gaps appear only when the workspace has a single child and leaves inner gaps alone.
Example configuration:
```
bindsym $mod+g gaps horizontal current toggle 640; gaps inner current toggle 30;
gaps horizontal 640
gaps inner 30
smart_gaps inverse_outer
```
README not updated until we can reach a conclusion on this.