### PR TITLE
Add documentation for smart_no_gaps extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ smart_borders no_gaps
 
 This extends i3's `hide_edge_borders` with a new option. When set, edge-specific borders of a container will be hidden if it's the only container on the workspace and the gaps to the screen edge is `0`.
 
+```
+# Hide edge borders only if there is one window with no gaps
+hide_edge_borders smart_no_gaps
+```
+
 ## i3bar
 
 ### Bar Height


### PR DESCRIPTION
Include the new option to the hide_edge_borders setting (smart_no_gaps) in
the readme.

I have wanted to use this setting for a while, but I wasn't sure what the readme was telling me to do. I couldn't get this feature out of a combination of the other options, so I always assumed I was doing something wrong. After reading the readme section over again, it seemed apparent that there was something missing. So, I poked in the source code and found the name of the new option, smart_no_gaps, and am now proposing this pull request to add documentation for it into the readme.