### PR TITLE
Setting negative gap #262

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -2299,19 +2299,16 @@ void cmd_gaps(I3_CMD, const char *type, const char *scope, const char *mode, con
         CMD_SET_GAPS_VALUE(type, current_value, reset);                                                         \
     } while (0)
 
-#define CMD_UPDATE_GAPS(type)                                                         \
-    do {                                                                              \
-        if (!strcmp(scope, "all")) {                                                  \
-            if (config.gaps.type + config.gaps.inner < 0)                             \
-                CMD_SET_GAPS_VALUE(type, -config.gaps.inner, true);                   \
-        } else {                                                                      \
-            if (config.gaps.type + workspace->gaps.type +                             \
-                    config.gaps.inner + workspace->gaps.inner <                       \
-                0) {                                                                  \
-                CMD_SET_GAPS_VALUE(type,                                              \
-                                   -config.gaps.inner - workspace->gaps.inner, true); \
-            }                                                                         \
-        }                                                                             \
+#define CMD_UPDATE_GAPS(type)                                                                              \
+    do {                                                                                                   \
+        if (!strcmp(scope, "all")) {                                                                       \
+            if (config.gaps.type + config.gaps.inner < 0)                                                  \
+                CMD_SET_GAPS_VALUE(type, -config.gaps.inner, true);                                        \
+        } else {                                                                                           \
+            if (config.gaps.type + workspace->gaps.type + config.gaps.inner + workspace->gaps.inner < 0) { \
+                CMD_SET_GAPS_VALUE(type, -config.gaps.inner - workspace->gaps.inner, true);                \
+            }                                                                                              \
+        }                                                                                                  \
     } while (0)
 
     if (!strcmp(type, "inner")) {

--- a/src/commands.c
+++ b/src/commands.c
@@ -2262,58 +2262,57 @@ void cmd_gaps(I3_CMD, const char *type, const char *scope, const char *mode, con
         } else {                                                        \
             workspace->gaps.type = value - config.gaps.type;            \
         }                                                               \
-    } while(0)
-
-#define CMD_GAPS(type)                                                  \
-    do {                                                                \
-        int current_value = config.gaps.type;                           \
-        if (strcmp(scope, "current") == 0)                              \
-            current_value += workspace->gaps.type;                      \
-                                                                        \
-        bool reset = false;                                             \
-        if (!strcmp(mode, "plus"))                                      \
-            current_value += pixels;                                    \
-        else if (!strcmp(mode, "minus"))                                \
-            current_value -= pixels;                                    \
-        else if (!strcmp(mode, "set")) {                                \
-            current_value = pixels;                                     \
-            reset = true;                                               \
-        } else if (!strcmp(mode, "toggle")) {                           \
-            current_value = !current_value * pixels;                    \
-            reset = true;                                               \
-        } else {                                                        \
-            ELOG("Invalid mode %s when changing gaps", mode);           \
-            ysuccess(false);                                            \
-            return;                                                     \
-        }                                                               \
-                                                                        \
-        /* see issue 262 */                                             \
-        int min_value = 0;                                              \
-        if (strcmp(#type, "inner") != 0) {                              \
-            min_value = strcmp(scope, "all") ?                          \
-                -config.gaps.inner-workspace->gaps.inner :              \
-                -config.gaps.inner;                                     \
-        }                                                               \
-                                                                        \
-        if (current_value < min_value)                                  \
-            current_value = min_value;                                  \
-                                                                        \
-        CMD_SET_GAPS_VALUE(type, current_value, reset);                 \
     } while (0)
 
-#define CMD_UPDATE_GAPS(type)                                           \
-    do {                                                                \
-        if (!strcmp(scope, "all")) {                                    \
-            if(config.gaps.type + config.gaps.inner < 0)                \
-                CMD_SET_GAPS_VALUE(type,-config.gaps.inner, true);      \
-        } else {                                                        \
-            if(config.gaps.type + workspace->gaps.type +                \
-                config.gaps.inner + workspace->gaps.inner < 0) {        \
-                CMD_SET_GAPS_VALUE(type,                                \
-                    -config.gaps.inner-workspace->gaps.inner, true);    \
-            }                                                           \
-        }                                                               \
-    } while(0)
+#define CMD_GAPS(type)                                                                                          \
+    do {                                                                                                        \
+        int current_value = config.gaps.type;                                                                   \
+        if (strcmp(scope, "current") == 0)                                                                      \
+            current_value += workspace->gaps.type;                                                              \
+                                                                                                                \
+        bool reset = false;                                                                                     \
+        if (!strcmp(mode, "plus"))                                                                              \
+            current_value += pixels;                                                                            \
+        else if (!strcmp(mode, "minus"))                                                                        \
+            current_value -= pixels;                                                                            \
+        else if (!strcmp(mode, "set")) {                                                                        \
+            current_value = pixels;                                                                             \
+            reset = true;                                                                                       \
+        } else if (!strcmp(mode, "toggle")) {                                                                   \
+            current_value = !current_value * pixels;                                                            \
+            reset = true;                                                                                       \
+        } else {                                                                                                \
+            ELOG("Invalid mode %s when changing gaps", mode);                                                   \
+            ysuccess(false);                                                                                    \
+            return;                                                                                             \
+        }                                                                                                       \
+                                                                                                                \
+        /* see issue 262 */                                                                                     \
+        int min_value = 0;                                                                                      \
+        if (strcmp(#type, "inner") != 0) {                                                                      \
+            min_value = strcmp(scope, "all") ? -config.gaps.inner - workspace->gaps.inner : -config.gaps.inner; \
+        }                                                                                                       \
+                                                                                                                \
+        if (current_value < min_value)                                                                          \
+            current_value = min_value;                                                                          \
+                                                                                                                \
+        CMD_SET_GAPS_VALUE(type, current_value, reset);                                                         \
+    } while (0)
+
+#define CMD_UPDATE_GAPS(type)                                                         \
+    do {                                                                              \
+        if (!strcmp(scope, "all")) {                                                  \
+            if (config.gaps.type + config.gaps.inner < 0)                             \
+                CMD_SET_GAPS_VALUE(type, -config.gaps.inner, true);                   \
+        } else {                                                                      \
+            if (config.gaps.type + workspace->gaps.type +                             \
+                    config.gaps.inner + workspace->gaps.inner <                       \
+                0) {                                                                  \
+                CMD_SET_GAPS_VALUE(type,                                              \
+                                   -config.gaps.inner - workspace->gaps.inner, true); \
+            }                                                                         \
+        }                                                                             \
+    } while (0)
 
     if (!strcmp(type, "inner")) {
         CMD_GAPS(inner);


### PR DESCRIPTION
Here's an implementation for [#262](https://github.com/Airblader/i3/issues/262)

This enables a negative outer gaps value also via keybindings. Currently it is only possible to set this directly in the configuration.

Example i3 configuration:
```
set $gaps 6
set $gaps_horizontal 470

smart_gaps inverse_outer

gaps inner $gaps
gaps outer -$gaps
# settings for my 21:9 monitor
gaps horizontal $gaps_horizontal

bindsym $mod+o gaps outer current set 10
bindsym $mod+g gaps outer current set -$gaps
bindsym $mod+Shift+g gaps outer current set -$gaps, gaps horizontal current set $gaps_horizontal
```

Maybe we can drop the `CMD_UPDATE_GAPS` function to make the code simpler. (I have implemented this function for completeness.)  It would be enough to replace the following:
```
if (current_value < 0)
    current_value = 0;
```

with:
```
int min_value = 0; 
if (strcmp(#type, "inner") != 0) {
    min_value = strcmp(scope, "all") ? -config.gaps.inner-workspace->gaps.inner : -config.gaps.inner;
}

if (current_value < min_value) 
    current_value = min_value;
```

