### PR TITLE
Change link to installation wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ i3-gaps is a fork of [i3wm](https://www.i3wm.org), a tiling window manager for X
 
 ## How do I install i3-gaps?
 
-Please refer to the [wiki](https://github.com/Airblader/i3/wiki).
+Please refer to the [wiki](https://github.com/Airblader/i3/wiki/installation).
 
 ## Where can I get help?
 


### PR DESCRIPTION
Take away one step between the README and the correct wiki page, improving the user experience, albeit only a little bit. :tada: