### PR TITLE
kick tray clients before destroying the bar

### DIFF
--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1621,6 +1621,8 @@ void destroy_window(i3_output *output) {
         return;
     }
 
+    kick_tray_clients(output);
+
     draw_util_surface_free(xcb_connection, &(output->bar));
     draw_util_surface_free(xcb_connection, &(output->buffer));
     draw_util_surface_free(xcb_connection, &(output->statusline_buffer));
@@ -1628,8 +1630,6 @@ void destroy_window(i3_output *output) {
     xcb_free_pixmap(xcb_connection, output->buffer.id);
     xcb_free_pixmap(xcb_connection, output->statusline_buffer.id);
     output->bar.id = XCB_NONE;
-
-    kick_tray_clients(output);
 }
 
 /* Strut partial tells i3 where to reserve space for i3bar. This is determined


### PR DESCRIPTION
nm-applet and redshift-gtk tray icons would not reappear after restarting i3.

```
(nm-applet:575): Gdk-WARNING **: 19:04:15.729: GdkWindow 0x1000002 unexpectedly destroyed

(nm-applet:575): GLib-GObject-WARNING **: 19:04:15.729: invalid (NULL) pointer instance

(nm-applet:575): GLib-GObject-CRITICAL **: 19:04:15.729: g_signal_handler_disconnect: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed

(nm-applet:575): Gdk-CRITICAL **: 19:04:15.730: gdk_frame_clock_end_updating: assertion 'GDK_IS_FRAME_CLOCK (frame_clock)' failed

(nm-applet:575): GLib-GObject-WARNING **: 19:04:15.730: ../glib/gobject/gsignal.c:2735: instance '0x5644e14a74e0' has no handler with id '276'

(nm-applet:575): Gdk-ERROR **: 19:04:15.731: The program 'nm-applet' received an X Window System error.
```
