### PR TITLE
Allow smart_gaps to be disabled with falsey values

### DIFF
--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -88,6 +88,8 @@ state SMART_BORDERS:
 state SMART_GAPS:
   enabled = '1', 'yes', 'true', 'on', 'enable', 'active'
       -> call cfg_smart_gaps($enabled)
+  enabled = '0', 'no', 'false', 'off', 'disable', 'inactive'
+      -> call cfg_smart_gaps($enabled)
   enabled = 'inverse_outer'
       -> call cfg_smart_gaps($enabled)
 


### PR DESCRIPTION
The prior way for users to disable smart_gaps is to remove the directive
entirely from their config. Some distributions of i3 such as Regolith
are designed to be [configured via Xresources][1]. Allowing the
directive to parse falsey values lets such users disable smart_gaps
without overriding the underlying i3 config.

[1]: https://github.com/regolith-linux/regolith-i3-gaps-config/blob/ce5a63e235cd24895f6e597c5025e9b0275055f8/config#L538-L540